### PR TITLE
Allow override of GitHub org via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ Jenkins, with necessary plugins and a modified seed job that will generate the
 jobs based on the vagrant shared folder (the top-level directory of this repo).
 Using this, you can make changes, run `vagrant rsync`, run the seed job, and
 see the results.
+
+If you would like to test the jobs against your own repos, you can set `CANDLEPIN_JENKINS_GITHUB_ORG` to your username
+(or another org where appropriate repos exist).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,8 +18,14 @@ Vagrant.configure(2) do |config|
     ansible.playbook = "ansible/bootstrap.yml"
   end
 
-  config.vm.provision "ansible_local" do |ansible|
+  config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ansible/vagrant.yml"
     ansible.galaxy_role_file = "ansible/requirements.yml"
+    ansible.extra_vars = {}
+    ENV.each do |key, value|
+      if key.start_with?('CANDLEPIN') then
+        ansible.extra_vars[key] = value
+      end
+    end
   end
 end

--- a/ansible/templates/seed.groovy.j2
+++ b/ansible/templates/seed.groovy.j2
@@ -1,5 +1,6 @@
 job('Development Seed Job') {
     customWorkspace('/vagrant/')
+    environmentVariables(CANDLEPIN_JENKINS_GITHUB_ORG: '{{ CANDLEPIN_JENKINS_GITHUB_ORG }}')
     steps {
         gradle 'clean test'
         dsl {

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -13,6 +13,8 @@
       - ws-cleanup
       - htmlpublisher
       - ansicolor
+      - envinject
+    CANDLEPIN_JENKINS_GITHUB_ORG: candlepin
   roles:
     - geerlingguy.jenkins
 
@@ -20,6 +22,9 @@
     - name: disable mail relay
       lineinfile: dest=/etc/postfix/main.cf line="default_transport = local:$myhostname"
       notify: reload postfix config
+
+    - name: template development seed job
+      template: src=templates/seed.groovy.j2 dest=/vagrant/ansible/seed.groovy
 
     - name: (re)generate development seed job
       command: ./gradlew rest -Dpattern=ansible/seed.groovy -DbaseUrl=http://{{ jenkins_hostname }}:{{ jenkins_http_port }}/ -Dusername={{ jenkins_admin_username }} -Dpassword={{ jenkins_admin_password }} chdir=/vagrant

--- a/jobs/pythonRHSMNoseTestsJob.groovy
+++ b/jobs/pythonRHSMNoseTestsJob.groovy
@@ -24,5 +24,6 @@ def pyrhsmJob = job("python-rhsm-nose-tests-pr-builder"){
     }
 }
 
-rhsmLib.addPullRequester(pyrhsmJob, rhsmLib.pythonRHSMRepo, 'jenkins-nose-tests')
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+rhsmLib.addPullRequester(pyrhsmJob, githubOrg, rhsmLib.pythonRHSMRepo, 'jenkins-nose-tests')
 rhsmLib.addCandlepinNotifier(pyrhsmJob)

--- a/jobs/submanNoseTestsJob.groovy
+++ b/jobs/submanNoseTestsJob.groovy
@@ -26,5 +26,6 @@ def rhsmJob = job("subscription-manager-nose-tests-pr"){
     }
 }
 
-rhsmLib.addPullRequester(rhsmJob, rhsmLib.submanRepo, 'jenkins-nosetests')
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+rhsmLib.addPullRequester(rhsmJob, githubOrg, rhsmLib.submanRepo, 'jenkins-nosetests')
 rhsmLib.addCandlepinNotifier(rhsmJob)

--- a/jobs/submanStylishTestsJob.groovy
+++ b/jobs/submanStylishTestsJob.groovy
@@ -23,5 +23,6 @@ def stylishJob = job("subscription-manager-stylish-tests-pr"){
     }
 }
 
-rhsmLib.addPullRequester(stylishJob, rhsmLib.submanRepo, 'jenkins-stylish')
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+rhsmLib.addPullRequester(stylishJob, githubOrg, rhsmLib.submanRepo, 'jenkins-stylish')
 rhsmLib.addCandlepinNotifier(stylishJob)

--- a/jobs/submanTitoTestsJob.groovy
+++ b/jobs/submanTitoTestsJob.groovy
@@ -23,5 +23,6 @@ def titoJob = job("subscription-manager-tito-tests-pr"){
     }
 }
 
-rhsmLib.addPullRequester(titoJob, rhsmLib.submanRepo, 'jenkins-tito')
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+rhsmLib.addPullRequester(titoJob, githubOrg, rhsmLib.submanRepo, 'jenkins-tito')
 rhsmLib.addCandlepinNotifier(titoJob)

--- a/src/main/groovy/jobLib/rhsmLib.groovy
+++ b/src/main/groovy/jobLib/rhsmLib.groovy
@@ -3,11 +3,11 @@ package jobLib
 import javaposse.jobdsl.dsl.Job
 
 class rhsmLib {
-    static String candlepinRepo = "candlepin/candlepin"
-    static String pythonRHSMRepo = "candlepin/python-rhsm"
-    static String submanRepo = "candlepin/subscription-manager"
+    static String candlepinRepo = "candlepin"
+    static String pythonRHSMRepo = "python-rhsm"
+    static String submanRepo = "subscription-manager"
 
-    static addPullRequester = { Job job, String repo, String name ->
+    static addPullRequester = { Job job, String githubOrg, String repo, String name ->
         job.with {
             parameters {
                 stringParam('sha1', 'master', 'GIT commit hash of what you want to test.')
@@ -15,7 +15,7 @@ class rhsmLib {
             scm {
                 git {
                     remote {
-                        github(repo)
+                        github("${githubOrg}/${repo}")
                         refspec('+refs/pull/*:refs/remotes/origin/pr/*')
                     }
                     branch('${sha1}')
@@ -28,7 +28,7 @@ class rhsmLib {
                     permitAll(false)
                     allowMembersOfWhitelistedOrgsAsAdmin(true)
                     cron('H/5 * * * *')
-                    orgWhitelist('candlepin')
+                    orgWhitelist(githubOrg)
                     extensions {
                         commitStatus {
                             context(name)


### PR DESCRIPTION
CANDLEPIN_JENKINS_GITHUB_ORG when set will override what github org is
used as the base for the jobs.

This allows one to point the jobs at ones own repo, rather than at the
central repos.

Had to switch from ansible_local to ansible because of a [vagrant
bug](https://github.com/mitchellh/vagrant/issues/6726). The bug is fixed
in 1.8.2, but f24 has 1.8.1, so I figure it's better to just switch for
now at least, even though I prefer ansible_local for having less deps on
the host machine.