### PR TITLE
Port candlepin jobs and add candlepin pipeline

### DIFF
--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -5,6 +5,7 @@
     jenkins_plugins:
       - ansible
       - ansicolor
+      - build-timeout
       - config-file-provider
       - credentials-binding
       - email-ext

--- a/jobs/candlepinDockerImagesJob.groovy
+++ b/jobs/candlepinDockerImagesJob.groovy
@@ -1,0 +1,31 @@
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+
+job("$baseFolder/candlepin-docker-images") {
+    previousNames('candlepin-docker-images')
+    description('Periodically builds and pushes docker images from master')
+    label('docker')
+    scm {
+        github('candlepin/candlepin', 'master')
+    }
+    wrappers {
+        preBuildCleanup()
+        colorizeOutput()
+    }
+    logRotator{
+        daysToKeep(90)
+    }
+    triggers {
+        cron('H 6 * * 1')
+    }
+    steps {
+        shell readFileFromWorkspace('resources/candlepin-docker-build.sh')
+    }
+    publishers {
+        mailer('chainsaw@redhat.com')
+        irc {
+            channel('#candlepin')
+        }
+    }
+}

--- a/jobs/candlepinLintTestsJob.groovy
+++ b/jobs/candlepinLintTestsJob.groovy
@@ -1,0 +1,34 @@
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+
+def rhsmJob = job("$baseFolder/candlepin-pullrequest-lint") {
+    previousNames('candlepin-pullrequest-lint')
+    description('Runs a linter against Candlepin code, and other miscellaneous checks. Does not produce any installable products.')
+    label('docker')
+    concurrentBuild()
+    wrappers {
+        timeout {
+            noActivity(600)
+        }
+        preBuildCleanup()
+        colorizeOutput()
+    }
+    logRotator{
+        daysToKeep(90)
+        artifactNumToKeep(5)
+    }
+    steps {
+        shell readFileFromWorkspace('resources/candlepin-lint.sh')
+    }
+    publishers {
+        archiveArtifacts {
+            pattern('artifacts/*')
+            allowEmpty()
+        }
+    }
+}
+
+rhsmLib.addPullRequester(rhsmJob, githubOrg, rhsmLib.candlepinRepo, 'jenkins-checkstyle', false)

--- a/jobs/candlepinPerformanceTestsJob.groovy
+++ b/jobs/candlepinPerformanceTestsJob.groovy
@@ -1,4 +1,9 @@
-job("Candlepin Performance"){
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+
+job("$baseFolder/Candlepin Performance") {
+    previousNames('Candlepin Performance')
     description('This job runs candlepin performance tests')
     label('rhsm')
     wrappers {
@@ -31,17 +36,6 @@ job("Candlepin Performance"){
     }
     triggers {
         cron('H 3 * * 6')
-        githubPullRequest {
-            admins(['alikins','awood','mstead','wottop','bkearney','Ceiu','vritant','nguyenfilip','cnsnyder','barnabycourt','Lorquas'])
-            cron('H/5 * * * *')
-            triggerPhrase('test this please')
-            blackListTargetBranches(['0.9.23-hotfix','candlepin-0.9.49-HOTFIX','candlepin-0.9.51-HOTFIX','candlepin-0.9.54-HOTFIX'])
-            extensions {
-                commitStatus {
-                    context('jenkins-candlepin-performance')
-                }
-            }
-        }
     }
     steps {
         ansiblePlaybook('ansible/candlepin.yml') {

--- a/jobs/candlepinPipeline.groovy
+++ b/jobs/candlepinPipeline.groovy
@@ -1,0 +1,231 @@
+import hudson.plugins.ircbot.v2.IRCConnectionProvider
+
+String REPO = 'https://github.com/candlepin/candlepin'
+String GITHUB_CREDENTIALS_ID = 'github-api-token-as-username-password'
+String GITHUB_ACCOUNT = 'candlepin'
+String GITHUB_REPO = 'candlepin'
+String GITHUB_COMMIT = ghprbActualCommit ?: sha1
+String PENDING_MESSAGE = 'Build has been scheduled.'
+String SUCCESS_MESSAGE = 'Test(s) passed.'
+String FAILURE_MESSAGE = 'Test(s) failed.'
+String[] PERFORMANCE_BRANCH_BLACKLIST = [
+    '0.9.23-hotfix',
+    'candlepin-0.9.49-HOTFIX',
+    'candlepin-0.9.51-HOTFIX',
+    'candlepin-0.9.54-HOTFIX',
+]
+
+def sendIrcNotification = { channel, text ->
+    try {
+        IRCConnectionProvider.getInstance().currentConnection().send(channel, text)
+    } catch(e) {
+        echo "Unable to send IRC notification to ${channel}: ${e}"
+    }
+}
+
+stage('test') {
+    node('master') {
+        githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-pipeline', targetUrl: BUILD_URL)
+    }
+    def results = []
+    parallel(
+        'unit-tests': {
+            node('master') {
+                githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                        status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-candlepin-unittests', targetUrl: BUILD_URL)
+            }
+            def buildInstance = build(job: "candlepin-pullrequest-unittests", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]], propagate: false)
+            node('master') {
+                if (buildInstance.result == 'SUCCESS') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-candlepin-unittests', targetUrl: buildInstance.absoluteUrl)
+                }
+                else {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-candlepin-unittests', targetUrl: buildInstance.absoluteUrl)
+                }
+            }
+            results.add(buildInstance.result)
+        },
+        'lint': {
+            node('master') {
+                githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                        status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-checkstyle', targetUrl: BUILD_URL)
+            }
+            def buildInstance = build(job: "candlepin-pullrequest-lint", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]], propagate: false)
+            node('master') {
+                if (buildInstance.result == 'SUCCESS') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-checkstyle', targetUrl: buildInstance.absoluteUrl)
+                }
+                else {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-checkstyle', targetUrl: buildInstance.absoluteUrl)
+                }
+            }
+            results.add(buildInstance.result)
+        },
+        'performance': {
+            if (!PERFORMANCE_BRANCH_BLACKLIST.contains(ghprbTargetBranch)) {
+                node('master') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-candlepin-performance', targetUrl: BUILD_URL)
+                }
+                def buildInstance = build(job: "Candlepin Performance", parameters: [[
+                     $class: 'StringParameterValue',
+                     name  : 'ghprbActualCommit',
+                     value : "${sha1}"
+                ]], propagate: false)
+                node('master') {
+                    if (buildInstance.result == 'SUCCESS') {
+                        githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                                status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-candlepin-performance', targetUrl: buildInstance.absoluteUrl)
+                    } else {
+                        githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                                status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-candlepin-performance', targetUrl: buildInstance.absoluteUrl)
+                    }
+                }
+                results.add(buildInstance.result)
+            }
+        },
+        'rspec-postgres': {
+            node('master') {
+                githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                      status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-rspec-postgresql', targetUrl: BUILD_URL)
+            }
+            def buildInstance = build(job: "candlepin-pullrequest-spectests-postgresql", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]], propagate: false)
+            node('master') {
+                if (buildInstance.result == 'SUCCESS') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-rspec-postgresql', targetUrl: buildInstance.absoluteUrl)
+                }
+                else {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-rspec-postgresql', targetUrl: buildInstance.absoluteUrl)
+                }
+            }
+            results.add(buildInstance.result)
+        },
+        'rspec-mysql': {
+            node('master') {
+                githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                      status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-rspec-mysql', targetUrl: BUILD_URL)
+            }
+            def buildInstance = build(job: "candlepin-pullrequest-spectests-mysql", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]], propagate: false)
+            node('master') {
+                if (buildInstance.result == 'SUCCESS') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-rspec-mysql', targetUrl: buildInstance.absoluteUrl)
+                }
+                else {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-rspec-mysql', targetUrl: buildInstance.absoluteUrl)
+                }
+            }
+            results.add(buildInstance.result)
+        },
+        'rspec-hosted-postgres': {
+            node('master') {
+                githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                      status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-rspec-hosted-postgres', targetUrl: BUILD_URL)
+            }
+            def buildInstance = build(job: "candlepin-pullrequest-spectests-hosted-postgres", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]], propagate: false)
+            node('master') {
+                if (buildInstance.result == 'SUCCESS') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-rspec-hosted-postgres', targetUrl: buildInstance.absoluteUrl)
+                }
+                else {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-rspec-hosted-postgres', targetUrl: buildInstance.absoluteUrl)
+                }
+            }
+            results.add(buildInstance.result)
+        },
+        'jenkins-rspec-hosted-mysql': {
+            node('master') {
+                githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                      status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-rspec-hosted-mysql', targetUrl: BUILD_URL)
+            }
+            def buildInstance = build(job: "candlepin-pullrequest-spectests-hosted-mysql", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]], propagate: false)
+            node('master') {
+                if (buildInstance.result == 'SUCCESS') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-rspec-hosted-mysql', targetUrl: buildInstance.absoluteUrl)
+                }
+                else {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-rspec-hosted-mysql', targetUrl: buildInstance.absoluteUrl)
+                }
+            }
+            results.add(buildInstance.result)
+        },
+        'jenkins-rspec-qpid': {
+            node('master') {
+                githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                      status: 'PENDING', description: PENDING_MESSAGE, context: 'jenkins-rspec-qpid', targetUrl: BUILD_URL)
+            }
+            def buildInstance = build(job: "candlepin-pullrequest-spectests-qpid", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]], propagate: false)
+            node('master') {
+                if (buildInstance.result == 'SUCCESS') {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-rspec-qpid', targetUrl: buildInstance.absoluteUrl)
+                }
+                else {
+                    githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                            status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-rspec-qpid', targetUrl: buildInstance.absoluteUrl)
+                }
+            }
+            results.add(buildInstance.result)
+        },
+    )
+    node('master') {
+        def buildPassed = !results.contains('FAILURE') && !results.contains('ABORTED') && !results.contains('UNSTABLE')
+        if (!buildPassed) {
+            currentBuild.result = 'FAILURE'
+            githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                    status: 'FAILURE', description: FAILURE_MESSAGE, context: 'jenkins-pipeline', targetUrl: BUILD_URL)
+
+            String subject = "candlepin - build # ${env.BUILD_NUMBER} - Failure"
+            emailext(
+                subject: subject,
+                body: "${subject}:\n\nCheck console output at ${env.BUILD_URL} to view the results",
+                to: emailDestination,
+            )
+            sendIrcNotification('#candlepin', "candlepin build # ${env.BUILD_NUMBER} failed. See ${env.BUILD_URL} for details.")
+        }
+        else {
+            githubNotify(account: GITHUB_ACCOUNT, repo: GITHUB_REPO, credentialsId: GITHUB_CREDENTIALS_ID, sha: GITHUB_COMMIT,
+                    status: 'SUCCESS', description: SUCCESS_MESSAGE, context: 'jenkins-pipeline', targetUrl: BUILD_URL)
+        }
+    }
+}

--- a/jobs/candlepinPipelineJob.groovy
+++ b/jobs/candlepinPipelineJob.groovy
@@ -1,0 +1,49 @@
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+
+pipeline_helper = job("$baseFolder/candlepin pipeline helper") {
+    environmentVariables {
+        groovy('''
+            return [emailDestination: binding.variables.get('ghprbPullAuthorEmail') ?: binding.variables.get('GIT_AUTHOR_EMAIL') ?: 'chainsaw@redhat.com']
+        ''')
+    }
+    logRotator {
+        numToKeep(1)
+    }
+    steps {
+        downstreamParameterized {
+            trigger('candlepin') {
+                parameters {
+                    predefinedProp('sha1', '${GIT_COMMIT}')
+                    predefinedProp('ghprbActualCommit', '${ghprbActualCommit}')
+                    predefinedProp('emailDestination', '${emailDestination}')
+                    predefinedProp('ghprbTargetBranch', '${ghprbTargetBranch}')
+                }
+            }
+        }
+    }
+}
+
+pipeline = pipelineJob("$baseFolder/candlepin") {
+    description('Delivery Pipeline for candlepin')
+    parameters {
+        stringParam('sha1', 'master', 'GIT commit hash of what you want to test.')
+        stringParam('ghprbActualCommit', null, 'commit used to report status against a GitHub PR')
+        stringParam('ghprbTargetBranch', null, 'PR target branch')
+        stringParam('emailDestination', 'chainsaw@redhat.com', 'email address to report failures to')
+    }
+    logRotator {
+        numToKeep(20)
+    }
+    steps {
+        definition {
+            cps {
+                script(readFileFromWorkspace('jobs/candlepinPipeline.groovy'))
+            }
+        }
+    }
+}
+
+rhsmLib.addPullRequester(pipeline_helper, githubOrg, rhsmLib.candlepinRepo, 'jenkins-pipeline', true, false)

--- a/jobs/candlepinQpidTestsJob.groovy
+++ b/jobs/candlepinQpidTestsJob.groovy
@@ -1,0 +1,35 @@
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+
+def rhsmJob = job("$baseFolder/candlepin-pullrequest-spectests-qpid") {
+    previousNames('candlepin-pullrequest-spectests-qpid')
+    environmentVariables(CANDLEPIN_DATABASE: 'postgresql', CP_TEST_ARGS: '-q -r qpid_spec')
+    description("Compiles and deploys Candlepin and runs rspec tests against PostgreSQL with Qpid. Does not produce any installable products.")
+    label('docker')
+    concurrentBuild()
+    wrappers {
+        timeout {
+            noActivity(7200)
+        }
+        preBuildCleanup()
+        colorizeOutput()
+    }
+    logRotator{
+        daysToKeep(90)
+        artifactNumToKeep(5)
+    }
+    steps {
+        shell readFileFromWorkspace('resources/candlepin-rspec-tests.sh')
+    }
+    publishers {
+        archiveArtifacts {
+            pattern('artifacts/*')
+            allowEmpty()
+        }
+    }
+}
+
+rhsmLib.addPullRequester(rhsmJob, githubOrg, rhsmLib.candlepinRepo, 'jenkins-rspec-qpid', false)

--- a/jobs/candlepinRspecTestsJob.groovy
+++ b/jobs/candlepinRspecTestsJob.groovy
@@ -1,0 +1,47 @@
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+
+String[] databases = ['mysql', 'postgresql']
+String[] modes = ['hosted', 'standalone']
+def dbDescriptions = [mysql: 'MySQL/MariaDB', postgresql: 'PostgreSQL']
+def modeDescriptions = [standalone: '', hosted: ' with Candlepin configured like hosted']
+def cpTestArgs = [standalone: '-r', hosted: '-H']
+
+databases.each { db ->
+    modes.each { mode ->
+        String typeSuffix = mode == 'hosted' ? 'hosted-' : ''
+        String jobName = "candlepin-pullrequest-spectests-${typeSuffix}${db}"
+        def rhsmJob = job("$baseFolder/$jobName") {
+            previousNames(jobName)
+            environmentVariables(CANDLEPIN_DATABASE: db, CP_TEST_ARGS: cpTestArgs[mode])
+            description("Compiles and deploys Candlepin and runs rspec tests${modeDescriptions[mode]}, using a ${dbDescriptions[db]} backend. Does not produce any installable products.")
+            label('docker')
+            concurrentBuild()
+            wrappers {
+                timeout {
+                    noActivity(7200)
+                }
+                preBuildCleanup()
+                colorizeOutput()
+            }
+            logRotator{
+                daysToKeep(90)
+                artifactNumToKeep(5)
+            }
+            steps {
+                shell readFileFromWorkspace('resources/candlepin-rspec-tests.sh')
+            }
+            publishers {
+                archiveArtifacts {
+                    pattern('artifacts/*')
+                    allowEmpty()
+                }
+            }
+        }
+
+        rhsmLib.addPullRequester(rhsmJob, githubOrg, rhsmLib.candlepinRepo, "jenkins-rspec-${typeSuffix}${db}", false)
+    }
+}

--- a/jobs/candlepinUnitTestsJob.groovy
+++ b/jobs/candlepinUnitTestsJob.groovy
@@ -1,0 +1,34 @@
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+
+def rhsmJob = job("$baseFolder/candlepin-pullrequest-unittests") {
+    previousNames('candlepin-pullrequest-unittests')
+    description('Compiles candlepin and runs unit tests. Does not produce any installable products.')
+    label('docker')
+    concurrentBuild()
+    wrappers {
+        timeout {
+            noActivity(7200)
+        }
+        preBuildCleanup()
+        colorizeOutput()
+    }
+    logRotator{
+        daysToKeep(90)
+        artifactNumToKeep(5)
+    }
+    steps {
+        shell readFileFromWorkspace('resources/candlepin-unit-tests.sh')
+    }
+    publishers {
+        archiveArtifacts {
+            pattern('artifacts/*')
+            allowEmpty()
+        }
+    }
+}
+
+rhsmLib.addPullRequester(rhsmJob, githubOrg, rhsmLib.candlepinRepo, 'jenkins-candlepin-unittests', false)

--- a/jobs/folders.groovy
+++ b/jobs/folders.groovy
@@ -3,3 +3,7 @@ import jobLib.rhsmLib
 folder(rhsmLib.submanJobFolder) {
     description("This is folder for the subscription manager pipeline jobs.")
 }
+
+folder(rhsmLib.candlepinJobFolder) {
+    description("This is folder for the candlepin pipeline jobs.")
+}

--- a/resources/candlepin-docker-build.sh
+++ b/resources/candlepin-docker-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+echo $USER
+groups $USER
+env
+
+echo "Using workspace: $WORKSPACE"
+docker --version
+
+./docker/rebuild.sh -p

--- a/resources/candlepin-lint.sh
+++ b/resources/candlepin-lint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xe
+
+env | sort
+echo
+
+docker pull docker-registry.usersys.redhat.com/candlepin/candlepin-postgresql || true
+echo "Docker pull completed"
+
+# The docker container test script will know to copy out
+echo "Using workspace: $WORKSPACE"
+mkdir -p $WORKSPACE/artifacts/
+
+# make selinux happy via http://stackoverflow.com/a/24334000
+chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
+
+# Run the linter
+docker run -P --rm -t -v $WORKSPACE/artifacts/:/artifacts/ docker-registry.usersys.redhat.com/candlepin/candlepin-postgresql cp-test -l -b jenkins -c "${sha1}"

--- a/resources/candlepin-rspec-tests.sh
+++ b/resources/candlepin-rspec-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xe
+
+env | sort
+echo
+
+docker pull docker-registry.usersys.redhat.com/candlepin/candlepin-${CANDLEPIN_DATABASE} || true
+echo "Docker pull completed"
+
+# The docker container test script will know to copy out
+echo "Using workspace: $WORKSPACE"
+mkdir -p $WORKSPACE/artifacts/
+
+# make selinux happy via http://stackoverflow.com/a/24334000
+chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
+
+# Run the spec tests
+docker run -Pt --rm -v $WORKSPACE/artifacts/:/artifacts/ docker-registry.usersys.redhat.com/candlepin/candlepin-${CANDLEPIN_DATABASE} cp-test ${CP_TEST_ARGS} -c "${sha1}"

--- a/resources/candlepin-unit-tests.sh
+++ b/resources/candlepin-unit-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xe
+
+env | sort
+echo
+
+docker pull docker-registry.usersys.redhat.com/candlepin/candlepin-postgresql || true
+echo "Docker pull completed"
+
+# The docker container test script will know to copy out
+echo "Using workspace: $WORKSPACE"
+mkdir -p $WORKSPACE/artifacts/
+
+# make selinux happy via http://stackoverflow.com/a/24334000
+chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
+
+# Run the Candlepin unit tests
+docker run -Pt --rm -v $WORKSPACE/artifacts/:/artifacts/ docker-registry.usersys.redhat.com/candlepin/candlepin-postgresql cp-test -uuu -c "${sha1}"

--- a/src/main/groovy/jobLib/rhsmLib.groovy
+++ b/src/main/groovy/jobLib/rhsmLib.groovy
@@ -5,6 +5,7 @@ import javaposse.jobdsl.dsl.Job
 class rhsmLib {
     static String candlepinRepo = "candlepin"
     static String submanRepo = "subscription-manager"
+    static String candlepinJobFolder = "candlepin"
     static String submanJobFolder = "subscription-manager"
 
     static addPullRequester = { Job job, String githubOrg, String repo, String name, boolean trigger = true, boolean notify = true ->


### PR DESCRIPTION
It is probably easiest to digest this by doing the following:
 - `vagrant up`
 - (if you've done `vagrant up` for this repo prior to this): `vagrant provision`
 - visit `jenkins.example.com:8080`
 - login (admin:admin)
 - run the "Development Seed Job"
 - look at the jobs under the "candlepin" folder.

@Ceiu & @Lorquas, I'm asking that you review the candlepin jobs for completeness and other issues, please.

One notable change is that the jobs are triggered by the pipeline rather than by the Pull Request builder (similar to what we're doing for subscription-manager).

@vritant, I tried to incorporate the performance job into the pipeline while I was in the code. Please take a look at my changes to `jobs/candlepinPerformanceTestsJob.groovy` and how I'm invoking the job from `jobs/candlepinPipeline.groovy` in particular.

Thanks in advance. Please let me know if you have any questions.