### PR TITLE
getting vagrant to work

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,8 @@ Vagrant.configure(2) do |config|
   config.vm.box = "centos/7"
   config.vm.synced_folder ".", "/vagrant",
     type: "rsync",
-    owner: "jenkins",
-    group: "jenkins"
+    owner: "1001",
+    group: "1001"
 
   if Vagrant.has_plugin?("vagrant-hostmanager")
     config.hostmanager.enabled = true

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -1,6 +1,23 @@
 ---
 - hosts: all
   become: true
+
+  pre_tasks:
+    - name: create jenkins group
+      group:
+        name: jenkins
+        state: present
+        gid: 1001
+
+    - name: create jenkins user
+      user:
+        name: jenkins
+        state: present
+        uid: 1001
+        group: jenkins
+        home: /var/lib/jenkins
+        system: yes
+
   vars:
     java_packages:
       - java-1.8.0-openjdk
@@ -8,7 +25,6 @@
       - ansible
       - ansicolor
       - build-timeout
-      - config-file-provider
       - credentials-binding
       - email-ext
       - envinject
@@ -82,14 +98,3 @@
       retries: "60"
       delay: "5"
       changed_when: false
-
-    - name: create dummy config files
-      shell: >
-        echo "javaposse.jobdsl.plugin.ConfigFileProviderHelper.findConfigProvider(javaposse.jobdsl.dsl.ConfigFileType.Custom).save(new org.jenkinsci.plugins.configfiles.custom.CustomConfig('{{ item }}', '{{ item }}', 'dummy file', ''))" |
-        java -jar /opt/jenkins-cli.jar
-        -s http://localhost:8080/
-        groovy =
-        --username admin --password admin
-      with_items: "{{ jenkins_dummy_configs }}"
-      tags:
-        - dummyconfig

--- a/jobs/candlepinPerformanceTestsJob.groovy
+++ b/jobs/candlepinPerformanceTestsJob.groovy
@@ -8,11 +8,6 @@ job("$baseFolder/CandlepinPerformance") {
     label('rhsm')
     wrappers {
         preBuildCleanup()
-        configFiles {
-            file('candlepinPerformanceInventory') {
-                variable('PERF_INVENTORY')
-            }
-        }
         colorizeOutput()
     }
     properties {
@@ -43,7 +38,7 @@ job("$baseFolder/CandlepinPerformance") {
     }
     steps {
         ansiblePlaybook('ansible/candlepin.yml') {
-            inventoryPath('${PERF_INVENTORY}')
+            inventoryPath('/etc/performanceInventory')
             credentialsId('fe2c79db-3166-4e61-8996-a8e7de7fbb5c')
             additionalParameters('--extra-vars=\"candlepin_branch=${ghprbActualCommit} caracalla_branch=${caracalla_branch} candlepin_throughput_properties=${candlepin_throughput_properties} loop_over_apis_properties=${loop_over_apis_properties} jmeter_tests=${jmeter_tests} target_branch=${target_branch} keep_logs=${keep_logs}\"')
             colorizedOutput(true)

--- a/src/test/groovy/com/dslexample/JobScriptsSpec.groovy
+++ b/src/test/groovy/com/dslexample/JobScriptsSpec.groovy
@@ -1,12 +1,9 @@
 package com.dslexample
 
 import groovy.io.FileType
-import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.DslScriptLoader
 import javaposse.jobdsl.dsl.JobManagement
-import javaposse.jobdsl.plugin.ConfigFileProviderHelper
 import javaposse.jobdsl.plugin.JenkinsJobManagement
-import org.jenkinsci.plugins.configfiles.custom.CustomConfig
 import org.junit.ClassRule
 import org.jvnet.hudson.test.JenkinsRule
 import spock.lang.Shared
@@ -25,9 +22,6 @@ class JobScriptsSpec extends Specification {
     void 'test script #file.name'(File file) {
         given:
         JobManagement jm = new JenkinsJobManagement(System.out, [:], new File('.'))
-        def configProvider = ConfigFileProviderHelper.findConfigProvider(ConfigFileType.Custom)
-        CustomConfig config = new CustomConfig('id', 'candlepinPerformanceInventory', 'comment', 'content')
-        configProvider.save(config)
         // must run the folders script first for testing
         String folders = new File('jobs/folders.groovy').text
         new DslScriptLoader(jm).runScript(folders)


### PR DESCRIPTION
`vagrant destroy; vagrant up`  works now.

required changing how the rsync was mounted (using uid/gid). Also removed the dependency on the config file provider plugin.  The config file will now be provided by the rhsm-ansible project in /etc/performanceInventory, and has already been deployed to the build nodes.
