### PR TITLE
fixing broken network in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(2) do |config|
   if Vagrant.has_plugin?("vagrant-hostmanager")
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true
-    config.hostmanager.manage_guest = true
+    config.hostmanager.manage_guest = false
   end
 
   config.vm.define "jenkins" do |jenkins|

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: https://github.com/geerlingguy/ansible-role-jenkins
-  version: 2.6.0
+  version: 3.2.2
   name: geerlingguy.jenkins
 
 - src: https://github.com/geerlingguy/ansible-role-java

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -18,6 +18,12 @@
         home: /var/lib/jenkins
         system: yes
 
+    - name: fix resolv.conf
+      lineinfile:
+        path: /etc/resolv.conf
+        state: absent
+        line: "search example.com"
+
   vars:
     java_packages:
       - java-1.8.0-openjdk


### PR DESCRIPTION
Vagrant box couldn't resolve external hostnames which broke half the playbook.  Added this somewhat hacky lineinfile fix since I can't find a good way to do this from vagrant.  Also updated the jenkins role to 3.2.2 which uses the jenkins_plugin ansible module.