### PR TITLE
log into docker before trying to build and push images

### DIFF
--- a/jobs/candlepinDockerImagesJob.groovy
+++ b/jobs/candlepinDockerImagesJob.groovy
@@ -12,6 +12,9 @@ job("$baseFolder/candlepin-docker-images") {
     wrappers {
         preBuildCleanup()
         colorizeOutput()
+        credentialsBinding {
+            string('DOCKER-API-TOKEN', 'CANDLEPIN-DOCKER-API-TOKEN')
+        }
     }
     logRotator{
         daysToKeep(90)

--- a/resources/candlepin-docker-build.sh
+++ b/resources/candlepin-docker-build.sh
@@ -7,4 +7,5 @@ env
 echo "Using workspace: $WORKSPACE"
 docker --version
 
+docker login -u unused -p "$DOCKER-API-TOKEN" docker-registry.engineering.redhat.com
 ./docker/build-images -p


### PR DESCRIPTION
Logging into docker registry before trying to build and push.  The credential is stored and provided by the credentials plugin on the Jenkins master.