### PR TITLE
removing oracle tests

### DIFF
--- a/jobs/candlepinRspecTestsJob.groovy
+++ b/jobs/candlepinRspecTestsJob.groovy
@@ -4,9 +4,9 @@ String baseFolder = rhsmLib.candlepinJobFolder
 
 String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
 
-String[] databases = ['mysql', 'postgresql', 'oracle']
+String[] databases = ['mysql', 'postgresql']
 String[] modes = ['hosted', 'standalone']
-def dbDescriptions = [mysql: 'MySQL/MariaDB', postgresql: 'PostgreSQL', 'oracle': 'OracleDB']
+def dbDescriptions = [mysql: 'MySQL/MariaDB', postgresql: 'PostgreSQL']
 def modeDescriptions = [standalone: '', hosted: ' with Candlepin configured like hosted']
 def cpTestArgs = [standalone: '-r', hosted: '-H']
 

--- a/resources/candlepin-rspec-tests.sh
+++ b/resources/candlepin-rspec-tests.sh
@@ -15,7 +15,6 @@ TEST_DB=""
 case $CANDLEPIN_DATABASE in
   mysql) TEST_DB="-m";;
   postgresql) TEST_DB="-p";;
-  oracle) TEST_DB="-o";;
 esac
 
 ./docker/test $TEST_DB -c "cp-test ${CP_TEST_ARGS} -c ${sha1}" -n "rspec-${BUILD_TAG}"


### PR DESCRIPTION
Currently these jobs are disabled, this PR removes them (we will have to manually delete them if we want off the jenkins server)

Am I missing any oracle bits from this?