### PR TITLE
adding caching to docker build job

### DIFF
--- a/resources/candlepin-docker-build.sh
+++ b/resources/candlepin-docker-build.sh
@@ -8,4 +8,4 @@ echo "Using workspace: $WORKSPACE"
 docker --version
 
 docker login -u unused -p "$DOCKER_API_TOKEN" docker-registry.engineering.redhat.com
-./docker/build-images -p
+./docker/build-images -p -c


### PR DESCRIPTION
Related to: https://github.com/candlepin/candlepin/pull/2187

The images are regularly cleaned from the slaves, but if they are already there, I see no reason not to used cached layers.