### PR TITLE
Install python3.7 when running syspurpose nose tests

### DIFF
--- a/resources/syspurpose-nose-tests.sh
+++ b/resources/syspurpose-nose-tests.sh
@@ -8,6 +8,7 @@ fi
 echo "sha1:" "${sha1}"
 
 sudo dnf clean expire-cache
+sudo dnf install -y python37
 sudo dnf builddep subscription-manager.spec  # ensure we install any missing rpm deps
 
 pushd $WORKSPACE/syspurpose


### PR DESCRIPTION
- The syspurpose nose tests require python 3.7 to be present.