### PR TITLE
updating DockerCleanup job to use slave labels

### DIFF
--- a/jobs/dockerCleanupJob.groovy
+++ b/jobs/dockerCleanupJob.groovy
@@ -1,23 +1,14 @@
-String listOfSlaves(int start, int end) {
-  String slaveList = ""
-  for (i = start; i <= end; i++) {
-    slaveList = slaveList + "rhsm-jenkins-slave${i}.usersys.redhat.com"
-    if ( i < end ) {
-      slaveList = slaveList + ","
-    }
-  }
-  return slaveList
-}
-
 job("DockerCleanup"){
     description('This job deletes unused docker images across all the slave nodes.')
     label('rhsm')
     parameters {
-        stringParam('DOCKER_HOSTS', listOfSlaves(0,10), 'Hostnames of servers to run on.')
+        labelParam('NODE_LABEL') {
+          defaultValue('rhsm')
+          description('Select nodes')
+          allNodes('allCases', 'IgnoreOfflineNodeEligibility')
+        }
         booleanParam('RESTART_DOCKER', false, 'Restart docker afterwards if checked.')
-    }
-    wrappers {
-        sshAgent('fe2c79db-3166-4e61-8996-a8e7de7fbb5c')
+        booleanParam('CLEAR_BUILD_CACHE', false, 'Clear the docker build cache if checked.')
     }
     logRotator{
         numToKeep(10)

--- a/resources/docker-cleanup.sh
+++ b/resources/docker-cleanup.sh
@@ -1,17 +1,26 @@
 #!/bin/bash -x
 
-function jssh(){
-  ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no jenkins@${1} "${2}"
-}
+#docker images -q | xargs -r docker rmi -f
+#docker ps -aq | xargs -r docker rm -f
+#docker network rm $(docker network ls | awk '$3 == "bridge" && $2 != "bridge" { print $1 }')
+#docker volume ls -q | xargs -r docker volume rm
 
-for HOST in $(echo $DOCKER_HOSTS | sed "s/,/ /g"); do
-	# jssh ${HOST} "docker images | grep '<none>' | awk '{print \$3}' | xargs -r docker rmi"
-  # more agressive
-  jssh ${HOST} "docker images -q | xargs -r docker rmi -f"
-  jssh ${HOST} "docker ps -aq | xargs -r docker rm -f"
-  jssh ${HOST} "docker volume ls -q | xargs -r docker volume rm"
-  jssh ${HOST} 'docker network rm $(docker network ls | awk '"'"'$3 == "bridge" && $2 != "bridge" { print $1 }'"'"')'
-  if [ "$RESTART_DOCKER" = 'true' ]; then
-    jssh ${HOST} "sudo systemctl restart docker"
-  fi
-done
+# this does all of the above now
+if [ "$CLEAR_BUILD_CACHE" = 'true' ]; then
+  docker system prune -a -f
+  # add --volumes to the above whenever on Docker 17.06.1
+  docker volume prune -f
+else
+  # everything but the build cache
+  docker image prune -a -f
+  docker volume prune -f
+  docker container prune -f
+  docker network prune -f
+fi
+
+if [ "$RESTART_DOCKER" = 'true' ]; then
+  sudo systemctl restart docker
+fi
+
+
+


### PR DESCRIPTION
With new infra changes static slaves won't do;  using slave labels plugin now (which will self spawn a job on each node).  Also updated the docker commands for cleaning up.