### PR TITLE
Running subman jobs on subman nodes

### DIFF
--- a/src/jobs/seed.groovy
+++ b/src/jobs/seed.groovy
@@ -1,5 +1,5 @@
 job('Candlepin Seed Job') {
-    label('rhsm')
+    label('utils')
     wrappers {
         preBuildCleanup()
     }

--- a/src/jobs/submanNoseTestsJob.groovy
+++ b/src/jobs/submanNoseTestsJob.groovy
@@ -5,7 +5,7 @@ String baseFolder = rhsmLib.submanJobFolder
 def rhsmJob = job("$baseFolder/subscription-manager-nose-tests-pr"){
     previousNames("subscription-manager-nose-tests-pr")
     description('Welcome to the subscription-manager nose tests!')
-    label('rhsm')
+    label('subman')
     wrappers {
         preBuildCleanup()
         colorizeOutput('css')

--- a/src/jobs/submanPython3Job.groovy
+++ b/src/jobs/submanPython3Job.groovy
@@ -5,7 +5,7 @@ String baseFolder = rhsmLib.submanJobFolder
 def job = job("$baseFolder/subscription-manager-python3-tests-pr-builder"){
     previousNames("$baseFolder/python-rhsm-python3-tests-pr-builder")
     description("checkout subscription-manager PR, make sure we don't regress on Python 3 compatibility")
-    label('rhsm')
+    label('subman')
     wrappers {
         preBuildCleanup()
         timeout {

--- a/src/jobs/submanStylishTestsJob.groovy
+++ b/src/jobs/submanStylishTestsJob.groovy
@@ -8,7 +8,7 @@ String desc = "Run 'make stylish' on github pull requests for subscription-manag
 def stylishJob = job("$baseFolder/subscription-manager-stylish-tests-pr"){
     previousNames("subscription-manager-stylish-tests-pr")
     description(desc)
-    label('rhsm')
+    label('subman')
     wrappers {
         preBuildCleanup()
         colorizeOutput('css')

--- a/src/jobs/submanTitoTestsJob.groovy
+++ b/src/jobs/submanTitoTestsJob.groovy
@@ -8,7 +8,7 @@ String desc = "Run 'tito build --test --rpm' on github pull requests for subscri
 def titoJob = job("$baseFolder/subscription-manager-tito-tests-pr"){
     previousNames("subscription-manager-tito-tests-pr")
     description(desc)
-    label('rhsm')
+    label('rpmbuild')
     wrappers {
         preBuildCleanup()
         colorizeOutput('css')

--- a/src/resources/subscription-manager-nose-tests.sh
+++ b/src/resources/subscription-manager-nose-tests.sh
@@ -23,6 +23,7 @@ virtualenv env --system-site-packages -p python2 || true
 source env/bin/activate
 
 make install-pip-requirements
+pip install --user -r ./test-requirements.txt
 
 # build/test python-rhsm
 if [ -d $WORKSPACE/python-rhsm ]; then

--- a/src/resources/subscription-manager-tito-tests.sh
+++ b/src/resources/subscription-manager-tito-tests.sh
@@ -7,5 +7,7 @@ pushd "${WORKSPACE}"
 
 mkdir tito/
 
+sudo dnf builddep subscription-manager.spec -y
+
 # Get exit status from 'tito' not 'tee'
 ( set -o pipefail; tito build --output=tito/ --test --rpm | tee tito_results.txt )


### PR DESCRIPTION
To limit breakage I would like to reduce the usage of the uber 'rhsm' nodes and use nodes more tailored to subman testing.