### PR TITLE
Allows nose and stylish tests to use yum or dnf (which ever is available)

### DIFF
--- a/src/resources/subscription-manager-nose-tests.sh
+++ b/src/resources/subscription-manager-nose-tests.sh
@@ -15,10 +15,17 @@
 
 echo "sha1:" "${sha1}"
 
+# Decide which package manager to use
+if [ -a $(which dnf) ]; then
+    PM=dnf
+else
+    PM=yum
+fi
+
 cd $WORKSPACE
 
-sudo dnf clean expire-cache
-sudo dnf builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
+sudo $PM clean expire-cache
+sudo $PM builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
 virtualenv env --system-site-packages -p python2 || true
 source env/bin/activate
 

--- a/src/resources/subscription-manager-stylish-tests.sh
+++ b/src/resources/subscription-manager-stylish-tests.sh
@@ -15,10 +15,17 @@
 
 echo "sha1:" "${sha1}"
 
+# Decide which package manager to use
+if [ -a $(which dnf) ]; then
+    PM=dnf
+else
+    PM=yum
+fi
+
 cd $WORKSPACE
 
-sudo dnf clean expire-cache
-sudo dnf builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
+sudo $PM clean expire-cache
+sudo $PM builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
 virtualenv env -p python2
 source env/bin/activate
 


### PR DESCRIPTION
Some of our test systems require the use of yum instead of dnf (certain versions of Centos vs newer versions of Fedora).
This allows the nose and stylish test jobs to use yum where dnf is not available.