### PR TITLE
Handle when "which dnf" returns nothing on stdout

### DIFF
--- a/src/resources/subscription-manager-nose-tests.sh
+++ b/src/resources/subscription-manager-nose-tests.sh
@@ -16,7 +16,8 @@
 echo "sha1:" "${sha1}"
 
 # Decide which package manager to use
-if [ -a $(which dnf) ]; then
+which dnf
+if [ $? -eq 0 ]; then
     PM=dnf
 else
     PM=yum

--- a/src/resources/subscription-manager-stylish-tests.sh
+++ b/src/resources/subscription-manager-stylish-tests.sh
@@ -16,7 +16,8 @@
 echo "sha1:" "${sha1}"
 
 # Decide which package manager to use
-if [ -a $(which dnf) ]; then
+which dnf
+if [ $? -eq 0 ]; then
     PM=dnf
 else
     PM=yum


### PR DESCRIPTION
Another pass at the dnf / yum detection.
The first pass did not work well when $(which dnf) did not result in anything on stdout.
This uses the exitcode of which dnf to determine how to proceed.