### PR TITLE
Handle when "which dnf" returns nothing on stdout part 2

### DIFF
--- a/src/resources/subscription-manager-nose-tests.sh
+++ b/src/resources/subscription-manager-nose-tests.sh
@@ -16,8 +16,8 @@
 echo "sha1:" "${sha1}"
 
 # Decide which package manager to use
-which dnf
-if [ $? -eq 0 ]; then
+which dnf || EXITCODE=$?
+if [ $EXITCODE -eq 0 ]; then
     PM=dnf
 else
     PM=yum

--- a/src/resources/subscription-manager-stylish-tests.sh
+++ b/src/resources/subscription-manager-stylish-tests.sh
@@ -16,8 +16,8 @@
 echo "sha1:" "${sha1}"
 
 # Decide which package manager to use
-which dnf
-if [ $? -eq 0 ]; then
+which dnf || EXITCODE=$?
+if [ $EXITCODE -eq 0 ]; then
     PM=dnf
 else
     PM=yum


### PR DESCRIPTION
This accounts for the fact that bash will exit (unless certain
options are set) when a command exits with a non-zero code.
Now we can check the exitcode of "which dnf" without exiting bash.