### PR TITLE
Use label subman and removed one step from script.

### DIFF
--- a/src/jobs/submanNoseTestsJob.groovy
+++ b/src/jobs/submanNoseTestsJob.groovy
@@ -5,7 +5,7 @@ String baseFolder = rhsmLib.submanJobFolder
 def rhsmJob = job("$baseFolder/subscription-manager-nose-tests-pr"){
     previousNames("subscription-manager-nose-tests-pr")
     description('Welcome to the subscription-manager nose tests!')
-    label('subman-centos7')
+    label('subman')
     wrappers {
         preBuildCleanup()
         colorizeOutput('css')

--- a/src/jobs/submanStylishTestsJob.groovy
+++ b/src/jobs/submanStylishTestsJob.groovy
@@ -8,7 +8,7 @@ String desc = "Run 'make stylish' on github pull requests for subscription-manag
 def stylishJob = job("$baseFolder/subscription-manager-stylish-tests-pr"){
     previousNames("subscription-manager-stylish-tests-pr")
     description(desc)
-    label('subman-centos7')
+    label('subman')
     wrappers {
         preBuildCleanup()
         colorizeOutput('css')

--- a/src/resources/subscription-manager-nose-tests.sh
+++ b/src/resources/subscription-manager-nose-tests.sh
@@ -47,11 +47,6 @@ PYTHON_RHSM=$(pwd)
 python setup.py build
 python setup.py build_ext --inplace
 
-# not using "setup.py nosetests" yet
-# since they need a running candlepin
-# yeah, kind of ugly...
-cp build/lib.linux-*/rhsm/_certificate.so src/rhsm/
-
 pushd $WORKSPACE
 export PYTHONPATH="$PYTHON_RHSM"/src
 

--- a/src/resources/subscription-manager-nose-tests.sh
+++ b/src/resources/subscription-manager-nose-tests.sh
@@ -16,8 +16,8 @@
 echo "sha1:" "${sha1}"
 
 # Decide which package manager to use
-which dnf || EXITCODE=$?
-if [ $EXITCODE -eq 0 ]; then
+which dnf
+if [ $? -eq 0 ]; then
     PM=dnf
 else
     PM=yum
@@ -26,7 +26,7 @@ fi
 cd $WORKSPACE
 
 sudo $PM clean expire-cache
-if [ $PM -eq 'dnf' ]; then
+if [ $PM = 'dnf' ]; then
     sudo $PM builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
     virtualenv env --system-site-packages -p python3 || true
 else

--- a/src/resources/subscription-manager-python3-tests.sh
+++ b/src/resources/subscription-manager-python3-tests.sh
@@ -16,15 +16,15 @@
 
 echo "sha" "${sha1}"
 
-which dnf || EXITCODE=$?
-if [ $EXITCODE -eq 0 ]; then
+which dnf
+if [ $? -eq 0 ]; then
     PM=dnf
 else
     PM=yum
 fi
 
 sudo $PM clean expire-cache
-if [ $PM -eq 'dnf' ]; then
+if [ $PM = 'dnf' ]; then
     sudo $PM builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
 fi
 virtualenv env -p python3 --system-site-packages || virtualenv-3 env --system-site-packages || true

--- a/src/resources/subscription-manager-stylish-tests.sh
+++ b/src/resources/subscription-manager-stylish-tests.sh
@@ -16,8 +16,8 @@
 echo "sha1:" "${sha1}"
 
 # Decide which package manager to use
-which dnf || EXITCODE=$?
-if [ $EXITCODE -eq 0 ]; then
+which dnf
+if [ $? -eq 0 ]; then
     PM=dnf
 else
     PM=yum
@@ -26,7 +26,7 @@ fi
 cd $WORKSPACE
 
 sudo $PM clean expire-cache
-if [ $PM -eq 'dnf' ]; then
+if [ $PM = 'dnf' ]; then
     sudo $PM builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
     virtualenv env -p python3
 else

--- a/src/resources/syspurpose-nose-tests.sh
+++ b/src/resources/syspurpose-nose-tests.sh
@@ -7,8 +7,8 @@ fi
 
 echo "sha1:" "${sha1}"
 
-which dnf || EXITCODE=$?
-if [ $EXITCODE -eq 0 ]; then
+which dnf
+if [ $? -eq 0 ]; then
     PM=dnf
 else
     PM=yum
@@ -16,7 +16,7 @@ fi
 
 sudo $PM clean expire-cache
 sudo $PM install -y python37
-if [ $PM -eq 'dnf' ]; then
+if [ $PM = 'dnf' ]; then
     sudo dnf builddep -y subscription-manager.spec  # ensure we install any missing rpm deps
 fi
 


### PR DESCRIPTION
* Use label subman and not subman-centos7. When the lable subman
  is used, then the job will be scheduled on nodes with Fedora
  and Python3
* Removed copying of _certificate.so to src/rhsm, because this
  step is useless. We already create certificate.so in src/rhsm
  using: 'python setup.py build_ext --inplace'