### PR TITLE
ENT-3110: Create Jenkins job for validating translation strings

### DIFF
--- a/src/jobs/candlepinValidateTranslationTestsJob.groovy
+++ b/src/jobs/candlepinValidateTranslationTestsJob.groovy
@@ -1,0 +1,35 @@
+import jobLib.rhsmLib
+
+String baseFolder = rhsmLib.candlepinJobFolder
+
+String githubOrg = binding.variables['CANDLEPIN_JENKINS_GITHUB_ORG'] ?: 'candlepin'
+
+def rhsmJob = job("$baseFolder/candlepin-pullrequest-validate-translation") {
+    previousNames('candlepin-pullrequest-validate-translation')
+    description('Runs a validator on translated files against Candlepin code')
+    label('docker')
+    concurrentBuild()
+    wrappers {
+        timeout {
+            noActivity(600)
+        }
+        preBuildCleanup()
+        colorizeOutput()
+    }
+    logRotator{
+        daysToKeep(90)
+        artifactNumToKeep(-1)
+        artifactDaysToKeep(2)
+    }
+    steps {
+        shell readFileFromWorkspace('src/resources/candlepin-validate-text.sh')
+    }
+    publishers {
+        archiveArtifacts {
+            pattern('artifacts/*')
+            allowEmpty()
+        }
+    }
+}
+
+rhsmLib.addPullRequester(rhsmJob, githubOrg, rhsmLib.candlepinRepo, 'jenkins-validate-translation', false)

--- a/src/resources/candlepin-validate-text.sh
+++ b/src/resources/candlepin-validate-text.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -x
+
+env | sort
+echo
+
+# The docker container test script will know to copy out
+echo "Using workspace: $WORKSPACE"
+mkdir -p $WORKSPACE/artifacts/
+
+# make selinux happy via http://stackoverflow.com/a/24334000
+chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
+
+# Run the validation on translations
+./docker/test -p -c 'cp-test -i -c "${sha1}"' -n "validate-${BUILD_TAG}"
+RETVAL=$?
+sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
+exit $RETVAL

--- a/src/resources/candlepinPipeline.groovy
+++ b/src/resources/candlepinPipeline.groovy
@@ -127,6 +127,13 @@ stage('test') {
                 name: 'pr_number',
                 value: "${ghprbPullId}"
             ]]))
+        },
+        'jenkins-validate-translation': {
+            results.add(buildWithNotifications(context: 'jenkins-validate-translation', job: "candlepin-pullrequest-validate-translation", parameters: [[
+                $class: 'StringParameterValue',
+                name: 'sha1',
+                value: "${sha1}"
+            ]]))
         }
     )
     node('master') {


### PR DESCRIPTION
 - Added a job to validate translated strings
 - Updated the candlepinPipeline with newly added job
 - A shell script to call and execute candlepin cp-test script