### PR TITLE
ENT-3109: Candlepin I18n job: cleanup workspace when job ends

### DIFF
--- a/src/jobs/candlepinInternationalizationJob.groovy
+++ b/src/jobs/candlepinInternationalizationJob.groovy
@@ -13,7 +13,7 @@ job("$baseFolder/candlepin-internationalization") {
         git {
             remote {
                 url('https://github.com/candlepin/candlepin.git')
-                credentials('bot_github_token')
+                credentials('github-api-token-as-username-password')
             }
             branch("master")
         }
@@ -28,5 +28,8 @@ job("$baseFolder/candlepin-internationalization") {
     }
     steps {
         shell readFileFromWorkspace('src/resources/candlepin-internationalization.sh')
+    }
+    publishers {
+        wsCleanup()
     }
 }


### PR DESCRIPTION
- Cleanup workspace when job ends, to avoid various git issues
  when the same checkout is reused between runs
- Use proper bot credentials when checking out candlepin