### PR TITLE
ENT-3432: Remove internal registry hostname from github

### DIFF
--- a/src/jobs/candlepinDockerImagesJob.groovy
+++ b/src/jobs/candlepinDockerImagesJob.groovy
@@ -13,7 +13,7 @@ job("$baseFolder/candlepin-docker-images") {
         preBuildCleanup()
         colorizeOutput()
         credentialsBinding {
-            string('DOCKER_API_TOKEN', 'CANDLEPIN-DOCKER-API-TOKEN')
+            usernamePassword('CANDLEPIN_QUAY_BOT_USER', 'CANDLEPIN_QUAY_BOT_TOKEN', 'candlepin-quay-bot')
         }
     }
     logRotator{
@@ -32,7 +32,7 @@ job("$baseFolder/candlepin-docker-images") {
                     alwaysRun()
                 }
                 steps {
-                    shell 'docker logout docker-registry.upshift.redhat.com'
+                    shell 'docker logout quay.io'
                 }
             }
         }

--- a/src/resources/candlepin-docker-build.sh
+++ b/src/resources/candlepin-docker-build.sh
@@ -7,7 +7,7 @@ env
 echo "Using workspace: $WORKSPACE"
 docker --version
 
-docker login -u unused -p "$DOCKER_API_TOKEN" docker-registry.upshift.redhat.com
+docker login -u "$CANDLEPIN_QUAY_BOT_USER" -p "$CANDLEPIN_QUAY_BOT_TOKEN" quay.io
 ./docker/build-images -p -c
 
 sudo setenforce 0


### PR DESCRIPTION
 - Updated the code to use `QUAY.IO` open source docker registry