### PR TITLE
Stop removing obsolete translations

### DIFF
--- a/src/resources/candlepin-internationalization.sh
+++ b/src/resources/candlepin-internationalization.sh
@@ -56,20 +56,16 @@ do
   ./gradlew gettext
   evalrc $? "Gettext was not successful for branch $GIT_BRANCH."
 
-  #Executing the msgattrib task
-  ./gradlew msgattrib
-  evalrc $? "msgattrib was not successful for branch $GIT_BRANCH."
-
   files=$(git diff | egrep -v -e '^( |\+#|\-#|@@|\+\+\+|\-\-\-|diff|index)' -e 'X-Generator' -e 'POT-Creation-Date')
 
   if [  ! -z  "$files" ]; then
 
-    #Code to commit the updated files
-    git add common/po
-    evalrc $? "Git add files was not successful for branch $GIT_BRANCH."
+    #Code to commit the updated template file
+    git add common/po/keys.pot
+    evalrc $? "Git add file was not successful for branch $GIT_BRANCH."
 
-    echo "Committing and pushing the files."
-    git -c "user.name=$GIT_AUTHOR_NAME" -c "user.email=$GIT_AUTHOR_EMAIL" commit -m "Internationalization: common/po files are updated"
+    echo "Committing and pushing the template file."
+    git -c "user.name=$GIT_AUTHOR_NAME" -c "user.email=$GIT_AUTHOR_EMAIL" commit -m "i18n: common/po/keys.pot template is updated"
     evalrc $? "Git commit was not successful for branch $GIT_BRANCH."
 
     git push https://${GITHUB_TOKEN}@github.com/candlepin/candlepin  $GIT_BRANCH


### PR DESCRIPTION
- There is no need to manually remove them from .po files
  because msgmerge will automatically mark them as obsolete
- Not touching the .po files will also avoid file conflicts
  when Weblate & this job edit the same files