### PR TITLE
ENT-3858: Removed 2.9-HOTFIX branch from candlepin internationalization job

### DIFF
--- a/src/resources/candlepin-internationalization.sh
+++ b/src/resources/candlepin-internationalization.sh
@@ -20,7 +20,7 @@ get_simplified_version() {
 
 git fetch --all
 
-for GIT_BRANCH in master candlepin-4.0-HOTFIX candlepin-3.2-HOTFIX candlepin-3.1-HOTFIX candlepin-2.9-HOTFIX
+for GIT_BRANCH in master candlepin-4.0-HOTFIX candlepin-3.2-HOTFIX candlepin-3.1-HOTFIX
 do
 
   #Clean the project


### PR DESCRIPTION
Removed 2.9-HOTFIX branch from candlepin internationalization job