### PR TITLE
Fix cleanup jobs

### DIFF
--- a/src/jobs/dockerCleanupJob.groovy
+++ b/src/jobs/dockerCleanupJob.groovy
@@ -1,9 +1,9 @@
 job("DockerCleanup"){
     description('This job deletes unused docker images across all the slave nodes.')
-    label('rhsm')
+    label('candlepin')
     parameters {
         labelParam('NODE_LABEL') {
-          defaultValue('rhsm')
+          defaultValue('candlepin')
           description('Select nodes')
           allNodes('allCases', 'IgnoreOfflineNodeEligibility')
         }

--- a/src/jobs/wsCleanupJob.groovy
+++ b/src/jobs/wsCleanupJob.groovy
@@ -2,7 +2,7 @@ job("WsCleanup"){
     description('This job deletes leftover ws-cleanup files across all the slave nodes.')
     parameters {
         labelParam('NODE_LABEL') {
-            defaultValue('rhsm')
+            defaultValue('candlepin')
             description('Select nodes')
             allNodes('allCases', 'IgnoreOfflineNodeEligibility')
         }

--- a/src/resources/ws-cleanup.sh
+++ b/src/resources/ws-cleanup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -x
 
-sudo find /home/jenkins/workspace/candlepin/ -name '*ws-cleanup*' -type d -prune -exec rm -rf {} +
+sudo find /home/jenkins/workspace -name '*candlepin_PR*' -type d -mtime +10 -prune -exec rm -rf {} +


### PR DESCRIPTION
- Update the label the WsCleanup and DockerCleanup jobs run against to 'candlepin', since 'rhsm' is deprecated.
- Update the WsCleanup job to look for the new workspace directory format, and only delete workspaces older than 10 days.