### PR TITLE
Disable candlepinPerformanceOverrideJob

### DIFF
--- a/src/jobs/candlepinPerformanceOverrideJob.groovy
+++ b/src/jobs/candlepinPerformanceOverrideJob.groovy
@@ -4,6 +4,7 @@ String baseFolder = rhsmLib.candlepinJobFolder
 
 job("$baseFolder/CandlepinPerformanceOverride") {
     description('Job that watches for performance OK by candlepin org members and marks a PR as PASS for performance. Use responsibly')
+    disabled()
     parameters {
         stringParam('sha1', null, 'sha1 of commit to PASS performance for')
     }


### PR DESCRIPTION
This job throws errors in the jenkins log and I don't see that it is ever used?  If you'd like I can also delete this and or any of the other performance jobs (the others are already disabled).