### PR TITLE
building with podman

### DIFF
--- a/src/resources/candlepin-docker-build.sh
+++ b/src/resources/candlepin-docker-build.sh
@@ -5,9 +5,10 @@ groups $USER
 env
 
 echo "Using workspace: $WORKSPACE"
-docker --version
+export CONTAINER_ENGINE="podman"
+"${CONTAINER_ENGINE}" --version
 
-docker login -u "$CANDLEPIN_QUAY_BOT_USER" -p "$CANDLEPIN_QUAY_BOT_TOKEN" quay.io
+"${CONTAINER_ENGINE}" login -u "$CANDLEPIN_QUAY_BOT_USER" -p "$CANDLEPIN_QUAY_BOT_TOKEN" quay.io
 ./docker/build-images -p -c
 
 sudo setenforce 0


### PR DESCRIPTION
Currently there is some bug with Docker (most likely our configuration of it) where it CPU limits commands run in the container.  When yum inside the container hits 100% CPU usage it hangs for some undetermined time and makes each package install VERY slow.  I've tried manually opening up Docker to use all CPUs and other available resources but this does not prevent any one CPU from hitting full usage.

Conveniently, podman does not have any of this problem, and since the build stage of candlepin tests don't strictly require docker, I'm doing a simple fix of using that for the builds only.

Note that this doesn't include a fix for the other build script in `docker/gating-test-images/build.sh`  and we will likely hit that problem there also.  This PR makes the job run much faster but we might need to discuss what to do in that script.

The counterpart to this PR is here: https://github.com/candlepin/candlepin/pull/3528