### PR TITLE
Disable subscripton-manager jobs by default

### DIFF
--- a/src/jobs/submanPipelineJob.groovy
+++ b/src/jobs/submanPipelineJob.groovy
@@ -3,7 +3,6 @@ import jobLib.rhsmLib
 String baseFolder = rhsmLib.submanJobFolder
 
 multibranchPipelineJob("${baseFolder}/subscription-manager") {
-  disabled()
   branchSources {
     // upstream; PRs only
     branchSource {
@@ -41,6 +40,7 @@ multibranchPipelineJob("${baseFolder}/subscription-manager") {
   }
   // TODO: remove this when issue is resolved > https://issues.jenkins-ci.org/browse/JENKINS-60874
   configure {
+    it / disabled << 'true'
     def traits = it / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
     traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
       strategyId(1)

--- a/src/jobs/submanPipelineJob.groovy
+++ b/src/jobs/submanPipelineJob.groovy
@@ -3,6 +3,7 @@ import jobLib.rhsmLib
 String baseFolder = rhsmLib.submanJobFolder
 
 multibranchPipelineJob("${baseFolder}/subscription-manager") {
+  disabled()
   branchSources {
     // upstream; PRs only
     branchSource {

--- a/src/jobs/submanSUSEUploadJob.groovy
+++ b/src/jobs/submanSUSEUploadJob.groovy
@@ -3,6 +3,7 @@ import jobLib.rhsmLib
 String baseFolder = rhsmLib.submanJobFolder
 
 def rhsmJob = job("$baseFolder/subscription-manager-suse-upload"){
+    disabled()
     description('Prepare and upload subman sources to the OpenSUSE Build Service')
     label('opensuse')
     parameters {

--- a/src/jobs/submanVagrantUpstreamImagesJob.groovy
+++ b/src/jobs/submanVagrantUpstreamImagesJob.groovy
@@ -2,6 +2,7 @@ import jobLib.rhsmLib
 String baseFolder = rhsmLib.submanJobFolder
 
 job("$baseFolder/vagrant-upstream-images") {
+    disabled()
     description('builds centos, fedora, etc. vagrant images for subman development')
     label('rhsm-packer')
     scm {


### PR DESCRIPTION
Leaving jobs/pipelines in-tact, just setting to disabled by default on seed.